### PR TITLE
(feat) Recompile lambda-promtail only on changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,10 @@ locals {
 resource "null_resource" "function_binary" {
   count = var.lambda_promtail_image == "" ? 1 : 0
   triggers = {
-    always_run = timestamp()
+    go_sha1s = sha1(join("", concat(
+      [for f in fileset("${path.module}/lambda-promtail", "*.go"): filesha1("${path.module}/lambda-promtail/${f}")],
+      [filesha1("${path.module}/go.mod"), filesha1("${path.module}/go.sum")]
+    )))
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
Rather than building it every single time we runplan or apply, only bother doing it when the contents of the Go code has changed.