### PR TITLE
Update deprecated attribute in aws_region data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -282,7 +282,7 @@ resource "aws_lambda_permission" "lambda_promtail_allow_cloudwatch" {
   statement_id  = "lambda-promtail-allow-cloudwatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.this.function_name
-  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+  principal     = "logs.${data.aws_region.current.region}.amazonaws.com"
 }
 
 # This block allows for easily subscribing to multiple log groups via the `log_group_names` var.


### PR DESCRIPTION
The attribute "name" is deprecated.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region