### PR TITLE
Support for URL-encoded keys from S3 event messages

### DIFF
--- a/pkg/s3_test.go
+++ b/pkg/s3_test.go
@@ -357,6 +357,70 @@ func Test_getLabels(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "s3_url_encoded_1",
+			args: args{
+				record: events.S3EventRecord{
+					AWSRegion: "us-east-1",
+					S3: events.S3Entity{
+						Bucket: events.S3Bucket{
+							Name: "cloudfront_logs_test",
+							OwnerIdentity: events.S3UserIdentity{
+								PrincipalID: "test",
+							},
+						},
+						Object: events.S3Object{
+							Key: "my/bucket/my%2Dprefix/E2K2LNL5N3WR51.2022-07-18-12.a10a8496.gz",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"bucket":        "cloudfront_logs_test",
+				"bucket_owner":  "test",
+				"bucket_region": "us-east-1",
+				"day":           "18",
+				"key":           "my/bucket/my-prefix/E2K2LNL5N3WR51.2022-07-18-12.a10a8496.gz",
+				"month":         "07",
+				"prefix":        "my/bucket/my-prefix",
+				"src":           "E2K2LNL5N3WR51",
+				"type":          CloudFrontLogType,
+				"year":          "2022",
+			},
+			wantErr: false,
+		},
+		{
+			name: "s3_url_encoded_2",
+			args: args{
+				record: events.S3EventRecord{
+					AWSRegion: "us-east-1",
+					S3: events.S3Entity{
+						Bucket: events.S3Bucket{
+							Name: "cloudfront_logs_test",
+							OwnerIdentity: events.S3UserIdentity{
+								PrincipalID: "test",
+							},
+						},
+						Object: events.S3Object{
+							Key: "my/bucket/my+prefix/E2K2LNL5N3WR51.2022-07-18-12.a10a8496.gz",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"bucket":        "cloudfront_logs_test",
+				"bucket_owner":  "test",
+				"bucket_region": "us-east-1",
+				"day":           "18",
+				"key":           "my/bucket/my prefix/E2K2LNL5N3WR51.2022-07-18-12.a10a8496.gz",
+				"month":         "07",
+				"prefix":        "my/bucket/my prefix",
+				"src":           "E2K2LNL5N3WR51",
+				"type":          CloudFrontLogType,
+				"year":          "2022",
+			},
+			wantErr: false,
+		},
+		{
 			name: "s3_waf",
 			args: args{
 				record: events.S3EventRecord{


### PR DESCRIPTION
I faced a problem with Lambda Promtail reading S3 CloudFront logs from an S3 bucket when using non-standard prefixes. e.g., `partitioned/year=2017/month=12/day=31/hour=23/EZTWSNRB71XP.2017-12-31-23.14d722e8.gz` because I have partitioned logs for use with Athena using Apache Hive style partitions.

In AWS S3 event messages, the object key name value is URL encoded (e.g., `red flower.jpg` becomes `red+flower.jpg`). This includes any object prefix (e.g., `year=2025/red flower.jpg` becomes `year%3D2025/red+flower.jpg`). (https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html) However,`GetObject` does not support passing a URL encoded value. 

This PR proposes using `url.QueryUnescape` to ensure that S3 object keys are handled properly for follow-up calls, such as `s3Client.GetObject`. This allows reading logs from an S3 bucket when the key contains URL-encoded values.