### PR TITLE
bugfix: replace lambda-promtail source dir reference with pkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 main
+
+# ignore build artifacts
+pkg/bootstrap
+pkg/*.zip


### PR DESCRIPTION

* previous [repo](https://github.com/grafana/loki/pull/18531) had the relative source directory in `/lambda-promtail`. In this repo, it has moved to `/pkg`. This causes the `function_binary` to fail because of missing directory and go files.
* update .gitignore to ignore terraform build artifacts