### PR TITLE
fix: always build the executable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,10 +196,7 @@ locals {
 resource "null_resource" "function_binary" {
   count = var.lambda_promtail_image == "" ? 1 : 0
   triggers = {
-    go_sha1s = sha1(join("", concat(
-      [for f in fileset("${path.module}/lambda-promtail", "*.go"): filesha1("${path.module}/lambda-promtail/${f}")],
-      [filesha1("${path.module}/go.mod"), filesha1("${path.module}/go.sum")]
-    )))
+    always_run = timestamp()
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
Always running the "go build" command to build the executable is necessary, since it is needed on every run.

This brings back the configuration from https://github.com/grafana/loki/blob/5aa8bd27946a1ce5267790ebe9210f93cd7111b2/tools/lambda-promtail/main.tf#L159 and resolves #36.