### PR TITLE
Ensure Prometheus registerer is not nil

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	prommodel "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -267,6 +268,7 @@ func handler(ctx context.Context, ev map[string]interface{}) error {
 		lvl = "info"
 	}
 	log := NewLogger(lvl)
+	metrics := prometheus.NewRegistry()
 	pClient := NewPromtailClient(&promtailClientConfig{
 		backoff: &backoff.Config{
 			MinBackoff: minBackoff,
@@ -279,7 +281,7 @@ func handler(ctx context.Context, ev map[string]interface{}) error {
 		},
 	}, log)
 
-	lokiStageConfigs, err := ParsePipelineConfigs(os.Getenv("LOKI_STAGE_CONFIGS"), *log, nil)
+	lokiStageConfigs, err := ParsePipelineConfigs(os.Getenv("LOKI_STAGE_CONFIGS"), *log, metrics)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When setting up the pipeline configs, I [originally provided a nil registerer](https://github.com/grafana/lambda-promtail/blob/7587290d744c7b055331f8658ecc567723dfeacc/pkg/main.go#L282). This is causing issues when using stage configurations that create their own metrics (e.g., `drop`) and the unit tests I created provided a [default Prometheus registry](https://github.com/grafana/lambda-promtail/blob/7587290d744c7b055331f8658ecc567723dfeacc/pkg/loki_stages_test.go#L22). This updates the main function to match this behavior.