### PR TITLE
feat(s3): support AWS ALB health check log filename format

### DIFF
--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -92,7 +92,7 @@ var (
 	// source: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
 	// format: aws-account-id/region/bucket-name/year/month/day/timestamp-hash
 	// example: 123456789012/us-west-2/amzn-s3-demo-source-bucket/2023/03/01/2023-03-01-21-32-16-E568B2907131C0C0
-	defaultFilenameRegex      = regexp.MustCompile(`AWSLogs\/(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/\d+\_(?:elasticloadbalancing|vpcflowlogs)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?P<lb_type>app|net)\.*?)?(?P<src>[a-zA-Z0-9\-]+)`)
+	defaultFilenameRegex      = regexp.MustCompile(`AWSLogs\/(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/(?:health_check_log_)?\d+\_(?:elasticloadbalancing|vpcflowlogs)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?P<lb_type>app|net)\.*?)?(?P<src>[a-zA-Z0-9\-]+)`)
 	defaultTimestampRegex     = regexp.MustCompile(`(?P<timestamp>\d+-\d+-\d+T\d+:\d+:\d+(?:\.\d+Z)?)`)
 	cloudtrailFilenameRegex   = regexp.MustCompile(`AWSLogs\/(?P<organization_id>o-[a-z0-9]{10,32})?\/?(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/\d+\_(?:CloudTrail|CloudTrail-Digest)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?:app|nlb|net)\.*?)?.+_(?P<src>[a-zA-Z0-9\-]+)`)
 	cloudfrontFilenameRegex   = regexp.MustCompile(`(?P<prefix>.*)\/(?P<src>[A-Z0-9]+)\.(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)-(.+)`)

--- a/pkg/s3_test.go
+++ b/pkg/s3_test.go
@@ -60,6 +60,40 @@ func Test_getLabels(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "s3_alb_health_check",
+			args: args{
+				record: events.S3EventRecord{
+					AWSRegion: "us-east-2",
+					S3: events.S3Entity{
+						Bucket: events.S3Bucket{
+							Name: "elb_logs_test",
+							OwnerIdentity: events.S3UserIdentity{
+								PrincipalID: "test",
+							},
+						},
+						Object: events.S3Object{
+							Key: "my-bucket/AWSLogs/123456789012/elasticloadbalancing/us-east-2/2022/05/01/health_check_log_123456789012_elasticloadbalancing_us-east-2_app.my-loadbalancer.1234567890abcdef_20220215T2340Z_172.160.001.192_20sg8hgm.log.gz",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"account_id":    "123456789012",
+				"bucket":        "elb_logs_test",
+				"bucket_owner":  "test",
+				"bucket_region": "us-east-2",
+				"day":           "01",
+				"key":           "my-bucket/AWSLogs/123456789012/elasticloadbalancing/us-east-2/2022/05/01/health_check_log_123456789012_elasticloadbalancing_us-east-2_app.my-loadbalancer.1234567890abcdef_20220215T2340Z_172.160.001.192_20sg8hgm.log.gz",
+				"month":         "05",
+				"region":        "us-east-2",
+				"lb_type":       LbAlbType,
+				"src":           "my-loadbalancer",
+				"type":          LbLogType,
+				"year":          "2022",
+			},
+			wantErr: false,
+		},
+		{
 			name: "s3_nlb",
 			args: args{
 				record: events.S3EventRecord{


### PR DESCRIPTION
## What

Add support for AWS ALB health check logs, a new log type [introduced by AWS in November 2025](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-health-check-logs.html).

## Why

ALB health check logs use a slightly different S3 key format than standard access logs:

```
# Standard ALB access log
.../AWSLogs/123456789012/elasticloadbalancing/region/yyyy/mm/dd/123456789012_elasticloadbalancing_...

# ALB health check log
.../AWSLogs/123456789012/elasticloadbalancing/region/yyyy/mm/dd/health_check_log_123456789012_elasticloadbalancing_...
```

The only difference is the `health_check_log_` prefix on the filename. This causes `getLabels()` to fail with `type of S3 event could not be determined` because `defaultFilenameRegex` doesn't account for the prefix.

## Changes

- `pkg/s3.go`: Add `(?:health_check_log_)?` optional group to `defaultFilenameRegex`
- `pkg/s3_test.go`: Add `s3_alb_health_check` test case to `Test_getLabels`

The health check log line format uses the same ISO 8601 timestamps as access logs, so no parser changes are needed. Health check logs are processed with the existing `LbLogType` parser and get the `s3_lb` log type label.

## Testing

All existing tests pass. New test case validates the health check log filename is correctly parsed with the same labels as standard ALB logs.
