### PR TITLE
Adding optional regex segment to parse vpc flow logs with hourly partition to fix grafana/lambda-promtail#9

### DIFF
--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -69,6 +69,9 @@ var (
 	// VPC Flow Logs
 	// source: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-path
 	// format: bucket-and-optional-prefix/AWSLogs/account_id/vpcflowlogs/region/year/month/day/aws_account_id_vpcflowlogs_region_flow_log_id_YYYYMMDDTHHmmZ_hash.log.gz
+	// VPC Flow Logs Hourly Format
+	// source: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-path.html#flow-logs-s3-path
+	// format: bucket-and-optional-prefix/AWSLogs/account_id/vpcflowlogs/region/year/month/day/hour/aws_account_id_vpcflowlogs_region_flow_log_id_YYYYMMDDTHHmmZ_hash.log.gz
 	// example: 123456789012_vpcflowlogs_us-east-1_fl-1234abcd_20180620T1620Z_fe123456.log.gz
 	// CloudTrail
 	// source: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-examples.html#cloudtrail-log-filename-format
@@ -92,7 +95,7 @@ var (
 	// source: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
 	// format: aws-account-id/region/bucket-name/year/month/day/timestamp-hash
 	// example: 123456789012/us-west-2/amzn-s3-demo-source-bucket/2023/03/01/2023-03-01-21-32-16-E568B2907131C0C0
-	defaultFilenameRegex      = regexp.MustCompile(`AWSLogs\/(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/(?:health_check_log_)?\d+\_(?:elasticloadbalancing|vpcflowlogs)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?P<lb_type>app|net)\.*?)?(?P<src>[a-zA-Z0-9\-]+)`)
+	defaultFilenameRegex      = regexp.MustCompile(`AWSLogs\/(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/(?:(?P<hour>\d+)\/)?(?:health_check_log_)?\d+\_(?:elasticloadbalancing|vpcflowlogs)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?P<lb_type>app|net)\.*?)?(?P<src>[a-zA-Z0-9\-]+)`)
 	defaultTimestampRegex     = regexp.MustCompile(`(?P<timestamp>\d+-\d+-\d+T\d+:\d+:\d+(?:\.\d+Z)?)`)
 	cloudtrailFilenameRegex   = regexp.MustCompile(`AWSLogs\/(?P<organization_id>o-[a-z0-9]{10,32})?\/?(?P<account_id>\d+)\/(?P<type>[a-zA-Z0-9_\-]+)\/(?P<region>[\w-]+)\/(?P<year>\d+)\/(?P<month>\d+)\/(?P<day>\d+)\/\d+\_(?:CloudTrail|CloudTrail-Digest)_(?:\w+-\w+-(?:\w+-)?\d)_(?:(?:app|nlb|net)\.*?)?.+_(?P<src>[a-zA-Z0-9\-]+)`)
 	cloudfrontFilenameRegex   = regexp.MustCompile(`(?P<prefix>.*)\/(?P<src>[A-Z0-9]+)\.(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)-(.+)`)

--- a/pkg/s3_test.go
+++ b/pkg/s3_test.go
@@ -259,6 +259,40 @@ func Test_getLabels(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "s3_hourly_flow_logs",
+			args: args{
+				record: events.S3EventRecord{
+					AWSRegion: "us-east-1",
+					S3: events.S3Entity{
+						Bucket: events.S3Bucket{
+							Name: "vpc_logs_test",
+							OwnerIdentity: events.S3UserIdentity{
+								PrincipalID: "test",
+							},
+						},
+						Object: events.S3Object{
+							Key: "my-bucket/AWSLogs/123456789012/vpcflowlogs/us-east-1/2026/08/06/20/123456789012_vpcflowlogs_us-east-1_fl-1234abcd_20260806T2020Z_fe123456.log.gz",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"account_id":    "123456789012",
+				"bucket":        "vpc_logs_test",
+				"bucket_owner":  "test",
+				"bucket_region": "us-east-1",
+				"hour":			 "20",
+				"day":           "06",
+				"key":           "my-bucket/AWSLogs/123456789012/vpcflowlogs/us-east-1/2026/08/06/20/123456789012_vpcflowlogs_us-east-1_fl-1234abcd_20260806T2020Z_fe123456.log.gz",
+				"month":         "08",
+				"region":        "us-east-1",
+				"src":           "fl-1234abcd",
+				"type":          FlowLogType,
+				"year":          "2026",
+			},
+			wantErr: false,
+		},
+		{
 			name: "cloudtrail_digest_logs",
 			args: args{
 				record: events.S3EventRecord{


### PR DESCRIPTION
## Fixes grafana/lambda-promtail#9
All I am doing is simply adding an optional regex segment to parse VPC flow logs with hourly partition.

The regex concerned here is `(?:(?P<hour>\d+)\/)?`:
- ?: makes sure we do not keep track of something like 20/ as that is what the outer group is matching
- ?P adding an 'hour' named group
- \d+ While d{2} would have been the better option, I am trying to follow the format that other calendar expressions are using
- \/ VPC flow logs with hourly partition will have a number like 20/ which we will have to match.

## Tests
I have added a unit test to test this change, and I have locally tested this change in my aws account using terraform successfully.
