### PR TITLE
fix(relabel): stop randomly dropping labels

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -195,6 +195,7 @@ func applyRelabelConfigs(labels model.LabelSet) model.LabelSet {
 	}
 
 	// Sort labels as required by Process
+	builder.Sort()
 	promLabels := builder.Labels()
 
 	// Apply relabeling

--- a/pkg/relabel_test.go
+++ b/pkg/relabel_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
 
@@ -125,5 +126,23 @@ func TestParseRelabelConfigs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Process input is built by ranging a Go map, whose order is randomized.
+// Without builder.Sort() the source_labels lookup intermittently misses and
+// the rule silently no-ops.
+func TestApplyRelabelConfigsSortsLabels(t *testing.T) {
+	var err error
+	relabelConfigs, err = parseRelabelConfigs(
+		`[{"source_labels":["_tst"],"regex":"^/svc/(.+)$","target_label":"out"}]`)
+	require.NoError(t, err)
+	t.Cleanup(func() { relabelConfigs = nil })
+
+	in := model.LabelSet{"_tst": "/svc/foo", "a": "1", "b": "2"}
+
+	for i := 0; i < 100; i++ {
+		require.Equal(t, model.LabelValue("foo"),
+			applyRelabelConfigs(in)["out"], "iteration %d", i)
 	}
 }


### PR DESCRIPTION
`applyRelabelConfigs` builds its input by ranging over a `model.LabelSet`, which is a `map`, so the order is random.
`relabel.Process` assumes sorted input when it resolves `source_labels`  so on some orderings the lookup misses,
 resolves empty, and the rule silently no-ops.

**Impact:** any rule using `source_labels` is intermittently skipped, with no error — the target label is just absent. 
In our deployment this dropped `service_name` on ~30% of CloudWatch events. 

There's an existing comment in `main.go` that calls out this requirement, but `builder.Sort()` was never actually called.

This PR just adds that missing call to `Sort()`

Added a tiny test that verifies the fix.

Likely also fixes #94 (labeldrop missing some matching labels)